### PR TITLE
hotfix: remove delimiter `~` from thread comments

### DIFF
--- a/biz/topic.py
+++ b/biz/topic.py
@@ -41,7 +41,7 @@ def prepare(threads):
         thread_ids.append(thread_id)
 
         topic = thread.topic
-        clean_comment = re.sub(r'[^a-zA-Z0-9\s]+', '', topic.text_comment).replace("\n", "")
+        clean_comment = re.sub(r'[^a-zA-Z0-9\s]+', '', topic.text_comment).replace("\n", "").replace("~","")
 
         Topic(thread_id, topic.subject, topic.thumbnail_url, clean_comment)
     return thread_ids


### PR DESCRIPTION
Remove delimiter `~` from thread comments to ensure we just have 4 values to unpack.

error: too many values to unpack.